### PR TITLE
Fixes style issues after release of bootstrap 4

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -18,7 +18,7 @@
     <link rel="mask-icon" href="%PUBLIC_URL%/safari-pinned-tab.svg" color="#5bbad5">
 
       <!-- Latest compiled and minified CSS -->
-      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
 
       <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 


### PR DESCRIPTION
It seems that the code was pointing to latest version pf bootstrap. The frontend is built with bootstrap 3. However, version 4 has recently been release and is quite different from v3. This messed up the design for the website, which has been fixed with this commit